### PR TITLE
Use iPhone 15 devices in simulator tests on Github CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           java-version: 11
       - name: Check
-        run: ./gradlew -PiosSimulatorMode=not_standalone check
+        run: ./gradlew -PiosSimulatorMode=standalone -PiosDevice="iPhone 15" check
       - name: Publish Linux
         if: matrix.os == 'ubuntu-latest'
         shell: bash

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [macOS-latest]
     steps:
       - name: Check out
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
         with:
           java-version: 11
       - name: Check
-        run: ./gradlew -PiosSimulatorMode=not_standalone check
+        run: ./gradlew -PiosSimulatorMode=standalone -PiosDevice="iPhone 15" check
       - name: Publish Linux to Maven Local
         if: matrix.os == 'ubuntu-latest'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: ./gradlew build -PintegrationTests=include
       - name: Check without integration
         if: matrix.os == 'macOS-latest'
-        run: ./gradlew build -PiosSimulatorMode=not_standalone -x jvmTest
+        run: ./gradlew build -PiosSimulatorMode=standalone -PiosDevice="iPhone 15" -x jvmTest
 
       # Uncomment the lines below to store test results for debugging failed tests (useful for iOS)
       # - name: Store test results


### PR DESCRIPTION
iPhone 14 is still listed in github's macos runner documentation but does not seem to be available anymore.